### PR TITLE
test: cover payout math, scoring, and putt-off tiebreaker logic

### DIFF
--- a/backend/src/routes/admin/payouts.test.ts
+++ b/backend/src/routes/admin/payouts.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest'
+import { getPayoutPercentages, calcDivisionPayouts, PayoutEntry } from './payouts.js'
+
+describe('getPayoutPercentages', () => {
+  it('returns [] for 0 players', () => {
+    expect(getPayoutPercentages(0)).toEqual([])
+  })
+
+  it('returns a single 100% slot for 1 player', () => {
+    expect(getPayoutPercentages(1)).toEqual([1.0])
+  })
+
+  it.each([
+    [2, 1], [3, 1],
+    [4, 2], [6, 2],
+    [7, 3], [9, 3],
+    [10, 4], [12, 4],
+    [13, 5], [15, 5],
+    [16, 6], [30, 6],
+  ])('count=%i returns %i payout slots', (count, expectedSlots) => {
+    expect(getPayoutPercentages(count)).toHaveLength(expectedSlots)
+  })
+
+  it('every tier sums to ~1.0 (within float rounding)', () => {
+    for (const count of [1, 2, 3, 4, 6, 7, 9, 10, 12, 13, 15, 16]) {
+      const pcts = getPayoutPercentages(count)
+      const sum = pcts.reduce((a, b) => a + b, 0)
+      expect(sum).toBeCloseTo(1.0, 5)
+    }
+  })
+
+  it('percentages are non-increasing (1st place gets the largest share)', () => {
+    for (const count of [3, 6, 9, 12, 15, 20]) {
+      const pcts = getPayoutPercentages(count)
+      for (let i = 1; i < pcts.length; i++) {
+        expect(pcts[i]).toBeLessThanOrEqual(pcts[i - 1])
+      }
+    }
+  })
+})
+
+describe('calcDivisionPayouts', () => {
+  it('returns [] when there are no ranked players', () => {
+    expect(calcDivisionPayouts(100, [], 'SPLIT')).toEqual([])
+  })
+
+  it('pays a single player the entire pool', () => {
+    const result = calcDivisionPayouts(100, [{ playerId: 'p1', playerName: 'A', totalScore: 50 }], 'SPLIT')
+    expect(result).toEqual([
+      { place: 1, playerId: 'p1', playerName: 'A', totalScore: 50, payout: 100, isTied: false, pendingPuttOff: false },
+    ])
+  })
+
+  // 7-9 ranked players land in the 3-slot tier: [0.475, 0.300, 0.225]
+  function fieldOf(count: number, scores: number[]) {
+    return Array.from({ length: count }, (_, i) => ({
+      playerId: `p${i + 1}`,
+      playerName: `P${i + 1}`,
+      totalScore: scores[i],
+    }))
+  }
+
+  it('distributes payouts by rank with no ties', () => {
+    const players = fieldOf(8, [30, 20, 10, 9, 8, 7, 6, 5])
+    const result = calcDivisionPayouts(1000, players, 'SPLIT')
+    expect(result.map(r => r.payout)).toEqual([475, 300, 225, 0, 0, 0, 0, 0])
+    expect(result.map(r => r.place)).toEqual([1, 2, 3, 4, 5, 6, 7, 8])
+    expect(result.every(r => !r.isTied)).toBe(true)
+  })
+
+  describe('SPLIT mode ties', () => {
+    it('splits a 2-way tie for 1st evenly, flooring remainders', () => {
+      const players = fieldOf(7, [30, 30, 10, 9, 8, 7, 6])
+      // pcts for 7 players: [0.475, 0.300, 0.225] → combined for slots 1+2 = 0.775 of pool
+      // pool=1000 → combinedAmount = floor(1000*0.775) = 775 → each gets floor(775/2)=387
+      const result = calcDivisionPayouts(1000, players, 'SPLIT')
+      const tied = result.filter(r => r.isTied)
+      expect(tied).toHaveLength(2)
+      expect(tied.every(r => r.payout === 387)).toBe(true)
+      expect(tied.every(r => r.place === 1)).toBe(true)
+      expect(tied.every(r => !r.pendingPuttOff)).toBe(true)
+      // 3rd place is untouched, uses dense rank 2 (not 3)
+      const third = result.find(r => r.playerId === 'p3')!
+      expect(third.place).toBe(2)
+      expect(third.payout).toBe(225)
+    })
+
+    it('splits a 3-way tie among all tied players', () => {
+      const players = [
+        { playerId: 'p1', playerName: 'A', totalScore: 10 },
+        { playerId: 'p2', playerName: 'B', totalScore: 10 },
+        { playerId: 'p3', playerName: 'C', totalScore: 10 },
+      ]
+      const result = calcDivisionPayouts(1000, players, 'SPLIT')
+      // combined = floor(1000 * (0.475+0.300+0.225)) = 1000, split 3 ways = floor(1000/3) = 333
+      expect(result).toHaveLength(3)
+      expect(result.every(r => r.payout === 333)).toBe(true)
+      expect(result.every(r => r.place === 1)).toBe(true)
+    })
+
+    it('gives $0 to a tied group occupying only unpaid places', () => {
+      // 6 players, tie for last (5th/6th) — pcts for 6 has only 6 slots, all > 0 in this tier,
+      // so use a bigger field where the tied group falls entirely outside paid slots.
+      const players = Array.from({ length: 20 }, (_, i) => ({
+        playerId: `p${i}`,
+        playerName: `P${i}`,
+        totalScore: i === 18 || i === 19 ? 0 : 20 - i, // last two tied at 0, outside the 6 paid slots
+      }))
+      const result = calcDivisionPayouts(1000, players, 'SPLIT')
+      const last = result.filter(r => r.totalScore === 0)
+      expect(last).toHaveLength(2)
+      expect(last.every(r => r.payout === 0)).toBe(true)
+      expect(last.every(r => r.isTied === true)).toBe(true)
+      expect(last.every(r => r.pendingPuttOff === false)).toBe(true)
+    })
+  })
+
+  describe('PUTT_OFF mode ties', () => {
+    const tiedPlayers = fieldOf(7, [30, 30, 10, 9, 8, 7, 6])
+
+    it('marks a 1st-place tie as pending when no putt-off winner is given', () => {
+      const result = calcDivisionPayouts(1000, tiedPlayers, 'PUTT_OFF')
+      const tied = result.filter(r => r.isTied)
+      expect(tied).toHaveLength(2)
+      expect(tied.every(r => r.payout === 0)).toBe(true)
+      expect(tied.every(r => r.pendingPuttOff === true)).toBe(true)
+    })
+
+    it('awards the full combined amount to the declared putt-off winner', () => {
+      const result = calcDivisionPayouts(1000, tiedPlayers, 'PUTT_OFF', 'p2')
+      const winner = result.find(r => r.playerId === 'p2')!
+      const loser = result.find(r => r.playerId === 'p1')!
+      // Note: 0.475 + 0.300 is 0.7749999999999999 in IEEE 754, so floor(1000 * combinedPct)
+      // lands on 774, one cent short of the mathematically "true" 775. This is a real
+      // floating-point precision artifact in calcDivisionPayouts, not a test quirk.
+      expect(winner.payout).toBe(774)
+      expect(winner.pendingPuttOff).toBe(false)
+      expect(loser.payout).toBe(0)
+      expect(loser.pendingPuttOff).toBe(false)
+      expect(loser.isTied).toBe(true)
+    })
+
+    it('treats an unrecognized putt-off winner id as still pending (defensive)', () => {
+      const result = calcDivisionPayouts(1000, tiedPlayers, 'PUTT_OFF', 'not-in-the-group')
+      const tied = result.filter(r => r.totalScore === 30)
+      expect(tied.every(r => r.payout === 0)).toBe(true)
+      expect(tied.every(r => r.pendingPuttOff === true)).toBe(true)
+    })
+
+    it('flags a tie as pending putt-off even when it is not for 1st place, as long as money is on the line', () => {
+      const players = fieldOf(8, [30, 10, 10, 9, 8, 7, 6, 5])
+      const result = calcDivisionPayouts(1000, players, 'PUTT_OFF')
+      const first = result.find(r => r.playerId === 'p1')!
+      expect(first.isTied).toBe(false)
+      expect(first.pendingPuttOff).toBe(false)
+      // p2/p3 tie for 2nd/3rd (combined slots worth 0.300+0.225 of the pool, i.e. real money)
+      const tied = result.filter(r => r.totalScore === 10)
+      expect(tied).toHaveLength(2)
+      expect(tied.every(r => r.pendingPuttOff === true)).toBe(true)
+      expect(tied.every(r => r.payout === 0)).toBe(true)
+    })
+
+    it('does not flag a $0 tie as pending, even in PUTT_OFF mode', () => {
+      // Only 3 players → single 100%-of-pool slot; a tie for 2nd (which pays $0) needs no putt-off.
+      const players = [
+        { playerId: 'p1', playerName: 'A', totalScore: 30 },
+        { playerId: 'p2', playerName: 'B', totalScore: 10 },
+        { playerId: 'p3', playerName: 'C', totalScore: 10 },
+      ]
+      const result = calcDivisionPayouts(1000, players, 'PUTT_OFF')
+      const tied = result.filter(r => r.totalScore === 10)
+      expect(tied.every(r => r.payout === 0)).toBe(true)
+      expect(tied.every(r => r.pendingPuttOff === false)).toBe(true)
+    })
+  })
+
+  it('never pays out more than the pool (flooring remainder is dropped, not distributed)', () => {
+    const players = [
+      { playerId: 'p1', playerName: 'A', totalScore: 3 },
+      { playerId: 'p2', playerName: 'B', totalScore: 2 },
+      { playerId: 'p3', playerName: 'C', totalScore: 1 },
+    ]
+    const pool = 101 // chosen to force flooring remainders
+    const result: PayoutEntry[] = calcDivisionPayouts(pool, players, 'SPLIT')
+    const total = result.reduce((sum, r) => sum + r.payout, 0)
+    expect(total).toBeLessThanOrEqual(pool)
+  })
+
+  it('handles a $0 pool without error', () => {
+    const players = [
+      { playerId: 'p1', playerName: 'A', totalScore: 3 },
+      { playerId: 'p2', playerName: 'B', totalScore: 3 },
+    ]
+    const result = calcDivisionPayouts(0, players, 'SPLIT')
+    expect(result.every(r => r.payout === 0)).toBe(true)
+  })
+})

--- a/backend/src/services/scoring.integration.test.ts
+++ b/backend/src/services/scoring.integration.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, beforeEach, afterEach, afterAll } from 'vitest'
+import { Position } from '@prisma/client'
+import { prisma } from '../lib/prisma.js'
+import { calcLeagueNightTotals, detectTies, upsertScore } from './scoring.js'
+import {
+  resetDb,
+  createDivision,
+  createPlayer,
+  createSeason,
+  createLeagueNight,
+  createHole,
+  createRound,
+  createScore,
+  waitFor,
+} from '../test/helpers.js'
+
+beforeEach(async () => {
+  await resetDb()
+})
+
+// upsertScore fires its audit-log write without awaiting it, so a truncate from the
+// *next* test's resetDb() can race an in-flight write from this one and log a harmless
+// (caught) FK error. Give it a beat to settle before we tear down.
+afterEach(async () => {
+  await new Promise(r => setTimeout(r, 100))
+})
+
+afterAll(async () => {
+  await prisma.$disconnect()
+})
+
+async function setupNight(overrides?: Parameters<typeof createLeagueNight>[1]) {
+  const division = await createDivision({ code: 'MPO' })
+  const season = await createSeason()
+  const leagueNight = await createLeagueNight(season.id, overrides)
+  const hole1 = await createHole(leagueNight.id, 1)
+  const hole2 = await createHole(leagueNight.id, 2)
+  const round1 = await createRound(leagueNight.id, 1)
+  return { division, season, leagueNight, hole1, hole2, round1 }
+}
+
+describe('calcLeagueNightTotals', () => {
+  it('sums made + bonus per player across holes and positions', async () => {
+    const { division, leagueNight, hole1, hole2, round1 } = await setupNight()
+    const { player: p1 } = await createPlayer(division.id)
+
+    await createScore({ playerId: p1.id, holeId: hole1.id, roundId: round1.id, position: Position.SHORT, made: 3 })
+    await createScore({ playerId: p1.id, holeId: hole2.id, roundId: round1.id, position: Position.LONG, made: 2 })
+
+    const totals = await calcLeagueNightTotals(leagueNight.id)
+    expect(totals).toHaveLength(1)
+    expect(totals[0]).toMatchObject({
+      playerId: p1.id,
+      totalMade: 5,
+      totalBonus: 1, // one 3-for-3
+      totalScore: 6,
+      shortMade: 3,
+      longMade: 2,
+      perfectRounds: 1,
+    })
+  })
+
+  it('sorts players by totalScore descending', async () => {
+    const { division, leagueNight, hole1, round1 } = await setupNight()
+    const { player: low } = await createPlayer(division.id, { name: 'Low' })
+    const { player: high } = await createPlayer(division.id, { name: 'High' })
+
+    await createScore({ playerId: low.id, holeId: hole1.id, roundId: round1.id, position: Position.SHORT, made: 1 })
+    await createScore({ playerId: high.id, holeId: hole1.id, roundId: round1.id, position: Position.SHORT, made: 3 })
+
+    const totals = await calcLeagueNightTotals(leagueNight.id)
+    expect(totals.map(t => t.playerId)).toEqual([high.id, low.id])
+  })
+
+  it('only counts a bonus once per score row, not per made putt', async () => {
+    const { division, leagueNight, hole1, hole2, round1 } = await setupNight()
+    const { player } = await createPlayer(division.id)
+
+    await createScore({ playerId: player.id, holeId: hole1.id, roundId: round1.id, position: Position.SHORT, made: 3 })
+    await createScore({ playerId: player.id, holeId: hole2.id, roundId: round1.id, position: Position.SHORT, made: 3 })
+
+    const totals = await calcLeagueNightTotals(leagueNight.id)
+    expect(totals[0].totalBonus).toBe(2)
+    expect(totals[0].perfectRounds).toBe(2)
+    expect(totals[0].totalScore).toBe(8) // 6 made + 2 bonus
+  })
+
+  it('returns [] when the league night has no scores', async () => {
+    const { leagueNight } = await setupNight()
+    const totals = await calcLeagueNightTotals(leagueNight.id)
+    expect(totals).toEqual([])
+  })
+})
+
+describe('detectTies', () => {
+  it('flags a tie for 1st within a division', async () => {
+    const { division, leagueNight, hole1, round1 } = await setupNight()
+    const { player: p1 } = await createPlayer(division.id, { name: 'A' })
+    const { player: p2 } = await createPlayer(division.id, { name: 'B' })
+
+    await createScore({ playerId: p1.id, holeId: hole1.id, roundId: round1.id, position: Position.SHORT, made: 2 })
+    await createScore({ playerId: p2.id, holeId: hole1.id, roundId: round1.id, position: Position.SHORT, made: 2 })
+
+    const ties = await detectTies(leagueNight.id)
+    expect(ties).toHaveLength(1)
+    expect(ties[0].divisionId).toBe(division.id)
+    expect(ties[0].tied.map(t => t.playerId).sort()).toEqual([p1.id, p2.id].sort())
+  })
+
+  it('does not flag a division with a unique top score', async () => {
+    const { division, leagueNight, hole1, round1 } = await setupNight()
+    const { player: p1 } = await createPlayer(division.id)
+    const { player: p2 } = await createPlayer(division.id)
+
+    await createScore({ playerId: p1.id, holeId: hole1.id, roundId: round1.id, position: Position.SHORT, made: 3 })
+    await createScore({ playerId: p2.id, holeId: hole1.id, roundId: round1.id, position: Position.SHORT, made: 1 })
+
+    const ties = await detectTies(leagueNight.id)
+    expect(ties).toEqual([])
+  })
+
+  it('does not flag a tie that is not for the top score', async () => {
+    const { division, leagueNight, hole1, round1 } = await setupNight()
+    const { player: p1 } = await createPlayer(division.id)
+    const { player: p2 } = await createPlayer(division.id)
+    const { player: p3 } = await createPlayer(division.id)
+
+    await createScore({ playerId: p1.id, holeId: hole1.id, roundId: round1.id, position: Position.SHORT, made: 3 })
+    await createScore({ playerId: p2.id, holeId: hole1.id, roundId: round1.id, position: Position.SHORT, made: 1 })
+    await createScore({ playerId: p3.id, holeId: hole1.id, roundId: round1.id, position: Position.SHORT, made: 1 })
+
+    const ties = await detectTies(leagueNight.id)
+    expect(ties).toEqual([])
+  })
+
+  it('scopes ties per division — a tie in one division does not affect another', async () => {
+    const { leagueNight, hole1, round1 } = await setupNight()
+    const divA = await createDivision({ code: 'A' })
+    const divB = await createDivision({ code: 'B' })
+    const { player: a1 } = await createPlayer(divA.id)
+    const { player: a2 } = await createPlayer(divA.id)
+    const { player: b1 } = await createPlayer(divB.id)
+    const { player: b2 } = await createPlayer(divB.id)
+
+    // Division A: tied for 1st
+    await createScore({ playerId: a1.id, holeId: hole1.id, roundId: round1.id, position: Position.SHORT, made: 2 })
+    await createScore({ playerId: a2.id, holeId: hole1.id, roundId: round1.id, position: Position.SHORT, made: 2 })
+    // Division B: clear winner
+    await createScore({ playerId: b1.id, holeId: hole1.id, roundId: round1.id, position: Position.SHORT, made: 3 })
+    await createScore({ playerId: b2.id, holeId: hole1.id, roundId: round1.id, position: Position.SHORT, made: 0 })
+
+    const ties = await detectTies(leagueNight.id)
+    expect(ties).toHaveLength(1)
+    expect(ties[0].divisionId).toBe(divA.id)
+  })
+})
+
+describe('upsertScore', () => {
+  it('creates a score and sets bonus=true for a 3-for-3', async () => {
+    const { division, hole1, round1 } = await setupNight()
+    const { player, user } = await createPlayer(division.id)
+
+    const score = await upsertScore({
+      playerId: player.id,
+      holeId: hole1.id,
+      roundId: round1.id,
+      position: Position.SHORT,
+      made: 3,
+      enteredBy: user.id,
+    })
+
+    expect(score.made).toBe(3)
+    expect(score.bonus).toBe(true)
+  })
+
+  it('does not set bonus for made < 3', async () => {
+    const { division, hole1, round1 } = await setupNight()
+    const { player, user } = await createPlayer(division.id)
+
+    const score = await upsertScore({
+      playerId: player.id,
+      holeId: hole1.id,
+      roundId: round1.id,
+      position: Position.SHORT,
+      made: 2,
+      enteredBy: user.id,
+    })
+
+    expect(score.bonus).toBe(false)
+  })
+
+  it('upserts — a second call for the same player/hole/round/position updates in place', async () => {
+    const { division, hole1, round1 } = await setupNight()
+    const { player, user } = await createPlayer(division.id)
+
+    const first = await upsertScore({
+      playerId: player.id, holeId: hole1.id, roundId: round1.id,
+      position: Position.SHORT, made: 1, enteredBy: user.id,
+    })
+    const second = await upsertScore({
+      playerId: player.id, holeId: hole1.id, roundId: round1.id,
+      position: Position.SHORT, made: 3, enteredBy: user.id,
+    })
+
+    expect(second.id).toBe(first.id)
+    expect(second.made).toBe(3)
+    expect(second.bonus).toBe(true)
+
+    const count = await prisma.score.count({ where: { playerId: player.id } })
+    expect(count).toBe(1)
+  })
+
+  it('rejects made > 3', async () => {
+    const { division, hole1, round1 } = await setupNight()
+    const { player, user } = await createPlayer(division.id)
+
+    await expect(upsertScore({
+      playerId: player.id, holeId: hole1.id, roundId: round1.id,
+      position: Position.SHORT, made: 4, enteredBy: user.id,
+    })).rejects.toThrow('made must be between 0 and 3')
+  })
+
+  it('rejects made < 0', async () => {
+    const { division, hole1, round1 } = await setupNight()
+    const { player, user } = await createPlayer(division.id)
+
+    await expect(upsertScore({
+      playerId: player.id, holeId: hole1.id, roundId: round1.id,
+      position: Position.SHORT, made: -1, enteredBy: user.id,
+    })).rejects.toThrow('made must be between 0 and 3')
+  })
+
+  it('writes an audit log entry recording prevMade → newMade', async () => {
+    const { leagueNight, division, hole1, round1 } = await setupNight()
+    const { player, user } = await createPlayer(division.id)
+
+    await upsertScore({
+      playerId: player.id, holeId: hole1.id, roundId: round1.id,
+      position: Position.SHORT, made: 1, enteredBy: user.id,
+    })
+    await upsertScore({
+      playerId: player.id, holeId: hole1.id, roundId: round1.id,
+      position: Position.SHORT, made: 3, enteredBy: user.id,
+    })
+
+    // Audit writes are fire-and-forget (do not block upsertScore's response), so poll for them.
+    const logs = await waitFor(async () => {
+      const rows = await prisma.scoreAuditLog.findMany({
+        where: { leagueNightId: leagueNight.id },
+      })
+      return rows.length === 2 ? rows : null
+    })
+
+    const sorted = logs.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime())
+    expect(sorted[0]).toMatchObject({ prevMade: null, newMade: 1 })
+    expect(sorted[1]).toMatchObject({ prevMade: 1, newMade: 3 })
+  })
+})

--- a/backend/src/services/tiebreaker.integration.test.ts
+++ b/backend/src/services/tiebreaker.integration.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { prisma } from '../lib/prisma.js'
+import { createPuttOff, recordPuttOffRound } from './tiebreaker.js'
+import {
+  resetDb,
+  createDivision,
+  createPlayer,
+  createSeason,
+  createLeagueNight,
+} from '../test/helpers.js'
+
+beforeEach(async () => {
+  await resetDb()
+})
+
+afterAll(async () => {
+  await prisma.$disconnect()
+})
+
+async function setupDivisionAndNight() {
+  const division = await createDivision()
+  const season = await createSeason()
+  const leagueNight = await createLeagueNight(season.id)
+  return { division, leagueNight }
+}
+
+describe('createPuttOff', () => {
+  it('creates a putt-off at round 1 with one participant per player, made defaulted to 0', async () => {
+    const { division, leagueNight } = await setupDivisionAndNight()
+    const { player: p1 } = await createPlayer(division.id)
+    const { player: p2 } = await createPlayer(division.id)
+
+    const puttOff = await createPuttOff(leagueNight.id, division.id, [p1.id, p2.id])
+
+    expect(puttOff.round).toBe(1)
+    expect(puttOff.winnerId).toBeNull()
+    expect(puttOff.participants).toHaveLength(2)
+    expect(puttOff.participants.every(p => p.made === 0 && p.round === 1)).toBe(true)
+    expect(puttOff.participants.map(p => p.playerId).sort()).toEqual([p1.id, p2.id].sort())
+  })
+})
+
+describe('recordPuttOffRound', () => {
+  it('declares a winner when one player has a strictly higher score', async () => {
+    const { division, leagueNight } = await setupDivisionAndNight()
+    const { player: p1 } = await createPlayer(division.id)
+    const { player: p2 } = await createPlayer(division.id)
+    const puttOff = await createPuttOff(leagueNight.id, division.id, [p1.id, p2.id])
+
+    const result = await recordPuttOffRound(puttOff.id, [
+      { playerId: p1.id, made: 3 },
+      { playerId: p2.id, made: 1 },
+    ])
+
+    expect(result).toEqual({ winnerId: p1.id, stillTied: false })
+
+    const updated = await prisma.puttOff.findUniqueOrThrow({ where: { id: puttOff.id } })
+    expect(updated.winnerId).toBe(p1.id)
+    expect(updated.round).toBe(1) // round does not advance once there's a winner
+  })
+
+  it('advances to the next round with only the tied players when scores are still tied', async () => {
+    const { division, leagueNight } = await setupDivisionAndNight()
+    const { player: p1 } = await createPlayer(division.id)
+    const { player: p2 } = await createPlayer(division.id)
+    const { player: p3 } = await createPlayer(division.id)
+    const puttOff = await createPuttOff(leagueNight.id, division.id, [p1.id, p2.id, p3.id])
+
+    const result = await recordPuttOffRound(puttOff.id, [
+      { playerId: p1.id, made: 2 },
+      { playerId: p2.id, made: 2 },
+      { playerId: p3.id, made: 0 },
+    ])
+
+    expect(result.stillTied).toBe(true)
+    expect(result.winnerId).toBeNull()
+    expect(result.tiedPlayerIds?.sort()).toEqual([p1.id, p2.id].sort())
+
+    const updated = await prisma.puttOff.findUniqueOrThrow({
+      where: { id: puttOff.id },
+      include: { participants: true },
+    })
+    expect(updated.round).toBe(2)
+    expect(updated.winnerId).toBeNull()
+
+    // Round 2 participants exist only for the still-tied players
+    const round2 = updated.participants.filter(p => p.round === 2)
+    expect(round2.map(p => p.playerId).sort()).toEqual([p1.id, p2.id].sort())
+    expect(round2.every(p => p.made === 0)).toBe(true)
+
+    // p3 (eliminated) has no round-2 entry
+    expect(updated.participants.some(p => p.playerId === p3.id && p.round === 2)).toBe(false)
+  })
+
+  it('resolves a multi-round putt-off: tie in round 1, winner in round 2', async () => {
+    const { division, leagueNight } = await setupDivisionAndNight()
+    const { player: p1 } = await createPlayer(division.id)
+    const { player: p2 } = await createPlayer(division.id)
+    const puttOff = await createPuttOff(leagueNight.id, division.id, [p1.id, p2.id])
+
+    const round1Result = await recordPuttOffRound(puttOff.id, [
+      { playerId: p1.id, made: 1 },
+      { playerId: p2.id, made: 1 },
+    ])
+    expect(round1Result.stillTied).toBe(true)
+
+    const round2Result = await recordPuttOffRound(puttOff.id, [
+      { playerId: p1.id, made: 3 },
+      { playerId: p2.id, made: 0 },
+    ])
+    expect(round2Result).toEqual({ winnerId: p1.id, stillTied: false })
+
+    const final = await prisma.puttOff.findUniqueOrThrow({ where: { id: puttOff.id } })
+    expect(final.winnerId).toBe(p1.id)
+    expect(final.round).toBe(2)
+  })
+
+  it('records made and bonus for every participant in the round, not just the winner', async () => {
+    const { division, leagueNight } = await setupDivisionAndNight()
+    const { player: p1 } = await createPlayer(division.id)
+    const { player: p2 } = await createPlayer(division.id)
+    const puttOff = await createPuttOff(leagueNight.id, division.id, [p1.id, p2.id])
+
+    await recordPuttOffRound(puttOff.id, [
+      { playerId: p1.id, made: 3 },
+      { playerId: p2.id, made: 1 },
+    ])
+
+    const participants = await prisma.puttOffParticipant.findMany({
+      where: { puttOffId: puttOff.id, round: 1 },
+    })
+    const p1Row = participants.find(p => p.playerId === p1.id)!
+    const p2Row = participants.find(p => p.playerId === p2.id)!
+    expect(p1Row).toMatchObject({ made: 3, bonus: true })
+    expect(p2Row).toMatchObject({ made: 1, bonus: false })
+  })
+})

--- a/backend/src/test/helpers.ts
+++ b/backend/src/test/helpers.ts
@@ -1,0 +1,109 @@
+import { prisma } from '../lib/prisma.js'
+import { Position } from '@prisma/client'
+
+/** Truncate all app tables. Call in beforeEach for test isolation. */
+export async function resetDb() {
+  await prisma.$executeRawUnsafe(`
+    TRUNCATE TABLE
+      "ScoreAuditLog", "PuttOffParticipant", "PuttOff", "CardPlayer", "Card",
+      "CheckIn", "Score", "Hole", "Round", "ScorekeeperAssignment",
+      "MagicLinkToken", "ForumReaction", "ForumComment", "ForumPost",
+      "PendingDigestItem", "NotificationPreference", "Player", "User",
+      "LeagueNight", "Season", "Division", "Settings", "Motd"
+    CASCADE;
+  `)
+}
+
+let counter = 0
+function uniq(prefix: string) {
+  counter += 1
+  return `${prefix}${counter}`
+}
+
+export async function createDivision(overrides: Partial<{ code: string; name: string; sortOrder: number; entryFee: number }> = {}) {
+  const code = overrides.code ?? uniq('DIV')
+  return prisma.division.create({
+    data: {
+      code,
+      name: overrides.name ?? code,
+      sortOrder: overrides.sortOrder ?? 0,
+      entryFee: overrides.entryFee ?? 8,
+    },
+  })
+}
+
+export async function createPlayer(divisionId: string | null, overrides: Partial<{ name: string; email: string }> = {}) {
+  const name = overrides.name ?? uniq('Player')
+  const user = await prisma.user.create({
+    data: {
+      email: overrides.email ?? `${uniq('user')}@example.com`,
+      name,
+    },
+  })
+  const player = await prisma.player.create({
+    data: { userId: user.id, divisionId },
+  })
+  return { user, player }
+}
+
+export async function createSeason(overrides: Partial<{ name: string; isActive: boolean }> = {}) {
+  return prisma.season.create({
+    data: {
+      name: overrides.name ?? uniq('Season'),
+      startDate: new Date('2026-01-01'),
+      isActive: overrides.isActive ?? true,
+    },
+  })
+}
+
+export async function createLeagueNight(seasonId: string, overrides: Partial<{ status: 'SCHEDULED' | 'IN_PROGRESS' | 'COMPLETED' | 'CANCELLED'; tieBreakerMode: 'SPLIT' | 'PUTT_OFF'; date: Date }> = {}) {
+  return prisma.leagueNight.create({
+    data: {
+      seasonId,
+      date: overrides.date ?? new Date('2026-02-01'),
+      status: overrides.status ?? 'IN_PROGRESS',
+      tieBreakerMode: overrides.tieBreakerMode ?? 'SPLIT',
+    },
+  })
+}
+
+export async function createHole(leagueNightId: string, number: number) {
+  return prisma.hole.create({ data: { leagueNightId, number } })
+}
+
+export async function createRound(leagueNightId: string, number: number) {
+  return prisma.round.create({ data: { leagueNightId, number } })
+}
+
+export async function createScore(params: {
+  playerId: string
+  holeId: string
+  roundId: string
+  position: Position
+  made: number
+  bonus?: boolean
+  enteredBy?: string | null
+}) {
+  return prisma.score.create({
+    data: {
+      playerId: params.playerId,
+      holeId: params.holeId,
+      roundId: params.roundId,
+      position: params.position,
+      made: params.made,
+      bonus: params.bonus ?? params.made === 3,
+      enteredBy: params.enteredBy ?? null,
+    },
+  })
+}
+
+/** Poll a condition until it's truthy or the timeout elapses. Useful for asserting on fire-and-forget async work. */
+export async function waitFor<T>(fn: () => Promise<T | null | undefined>, { timeoutMs = 2000, intervalMs = 25 } = {}): Promise<T> {
+  const start = Date.now()
+  for (;;) {
+    const result = await fn()
+    if (result) return result
+    if (Date.now() - start > timeoutMs) throw new Error('waitFor: timed out')
+    await new Promise(r => setTimeout(r, intervalMs))
+  }
+}

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -5,5 +5,11 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.test.ts'],
     globals: true,
+    // Integration tests share one Postgres database and truncate it between
+    // tests (see src/test/helpers.ts resetDb) — running files in parallel
+    // workers races those truncations against each other.
+    poolOptions: {
+      threads: { singleThread: true },
+    },
   },
 })


### PR DESCRIPTION
## Summary

The backend had exactly one test file covering a single pure function (`computeStationHole`). Everything else — including the payout/money math — shipped untested, despite CI already provisioning a real Postgres service for `npm test` that nothing exercised.

This PR goes from 5 tests (1 file) to 53 tests (4 files), focused on the highest-risk untested logic:

- **`backend/src/routes/admin/payouts.test.ts`** (29 tests, pure functions, no DB) — `getPayoutPercentages` tier boundaries and `calcDivisionPayouts` tie-splitting in both `SPLIT` and `PUTT_OFF` modes, rounding remainders, and defensive edge cases (unrecognized putt-off winner, $0 pool).
  - Along the way this surfaced a real floating-point precision artifact in the existing payout calculation: `0.475 + 0.300` evaluates to `0.7749999999999999` in JS, so a 2-way tie for 1st place with a $1000 pool pays out **$774** instead of the mathematically "true" $775 — a cent silently lost to float drift rather than the documented floor-to-EOY behavior. The test encodes and documents the actual behavior rather than papering over it; flagging here in case it's worth a follow-up fix (e.g. rounding cents before flooring).
- **`backend/src/services/scoring.integration.test.ts`** (14 tests, real DB) — `calcLeagueNightTotals` aggregation, `detectTies` (including per-division scoping), and `upsertScore` (bonus flagging, upsert semantics, bounds validation, and the fire-and-forget audit log).
- **`backend/src/services/tiebreaker.integration.test.ts`** (5 tests, real DB) — `createPuttOff` and multi-round `recordPuttOffRound` resolution, including a tie in round 1 resolving to a winner in round 2.
- **`backend/src/test/helpers.ts`** — fixture builders (division/player/season/league night/hole/round/score) and a truncate-based `resetDb()` for isolation between DB-backed tests.
- **`backend/vitest.config.ts`** — pinned to a single worker thread. The integration tests share one database and truncate it between cases; running test files in parallel workers races those truncations against each other.

## Test plan

- [x] `npm test` passes locally against a real Postgres instance (53/53), run 3x with no flakiness
- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds and doesn't ship anything unexpected (test files already compiled into `dist/` before this change, matching prior behavior — `dist/` is gitignored regardless)
- [x] CI's existing `test` job already spins up a matching Postgres service, runs migrations, and calls `npm test` — no workflow changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbFseeAZeh9cHuVDruJ473

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbFseeAZeh9cHuVDruJ473)_